### PR TITLE
fix: include order error

### DIFF
--- a/include/candle.hpp
+++ b/include/candle.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <memory>
 #include <vector>
 
 #include "bus.hpp"


### PR DESCRIPTION
When compiling devel branch without this include compiler error occur 
Kernel: 5.15.0-86-generic
g++ version: 11.4.0
cmake version: 3.22.1
make version: 4.3

