### PR TITLE
fix: include order error

### DIFF
--- a/src/usbDevice.cpp
+++ b/src/usbDevice.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <array>
 
 #include "bus.hpp"
 


### PR DESCRIPTION
This error prevented pywheel from compiling properly on gcc12